### PR TITLE
fix:close_by_window

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,9 @@ import shlex
 import subprocess
 from os import listdir
 from os.path import expanduser, isdir, join
-from typing import Dict, List, Union, Generator, Optional, Set, Tuple
+from typing import Dict, List, Union, Generator, Optional, Iterable
+from distutils.spawn import find_executable
+
 
 import psutil
 from langcodes import closest_match
@@ -30,6 +32,10 @@ class ApplicationLauncherSkill(FallbackSkill):
         if "user_commands" not in self.settings:
             # "application name": "bash command"
             self.settings["user_commands"] = {}
+
+        self.wmctrl = find_executable("wmctrl")
+        if not self.wmctrl:
+            LOG.warning("'wmctrl' not available, will not be able to manage windows directly only processes")
 
         self.applist = self.get_app_aliases()
         # this is a regex based intent parser
@@ -117,7 +123,46 @@ class ApplicationLauncherSkill(FallbackSkill):
                 LOG.error(f"Failed to launch {app}: {e}")
         return False
 
-    def close_app(self, app: str) -> bool:
+    def close_app(self, app: str):
+        if self.wmctrl:
+            return self.close_by_window(app) or self.close_by_process(app)
+        self.close_by_process(app)
+
+    def close_by_window(self, app: str) -> bool:
+        windows = self.get_window_process_mapping()
+        candidates = []
+        best = 0
+        for win in windows:
+            score = fuzzy_match(win[1].name(), app)
+            if score > best:
+                candidates = []
+            if score >= best:
+                candidates.append(win)
+                best = score
+
+        for win in candidates:
+            LOG.debug(f"Closing window '{win[0]}' : {win[-1]}")
+            self.close_window(win[0])
+            if not self.settings.get("terminate_all", False):
+                break
+
+        return True
+
+    def match_process(self, app: str) -> Iterable[psutil.Process]:
+        cmd, _ = match_one(app.title(), self.applist)
+        cmd = cmd.split(" ")[0].split("/")[-1]
+
+        # Retrieve the list of processes and sort by their start time (descending order)
+        processes = sorted(psutil.process_iter(['pid', 'name', 'create_time']),
+                           key=lambda proc: proc.info['create_time'], reverse=True)
+        for proc in processes:
+            if proc.status() in ["zombie"]:
+                continue
+            score = fuzzy_match(cmd, proc.info['name'])
+            if score > 0.9:
+                yield proc
+
+    def close_by_process(self, app: str) -> bool:
         """Close the application with the given name.
 
         Args:
@@ -126,20 +171,17 @@ class ApplicationLauncherSkill(FallbackSkill):
         Returns:
             True if the application was terminated successfully, False otherwise.
         """
-        cmd, _ = match_one(app.title(), self.applist)
-        cmd = cmd.split(" ")[0].split("/")[-1]
         terminated = []
-
-        for proc in psutil.process_iter(['pid', 'name']):
-            score = fuzzy_match(cmd, proc.info['name'])
-            if score > 0.9:
-                LOG.debug(f"Matched '{app}' to {proc}")
-                try:
-                    LOG.info(f"Terminating process: {proc.info['name']} (PID: {proc.info['pid']})")
-                    proc.terminate()  # or process.kill() to forcefully kill
-                    terminated.append(proc.info['pid'])
-                except (psutil.NoSuchProcess, psutil.AccessDenied):
-                    LOG.error(f"Failed to terminate {proc}")
+        for proc in self.match_process(app):
+            LOG.debug(f"Matched '{app}' to {proc}")
+            try:
+                LOG.info(f"Terminating process: {proc.info['name']} (PID: {proc.info['pid']})")
+                proc.terminate()  # or process.kill() to forcefully kill
+                terminated.append(proc.info['pid'])
+                if not self.settings.get("terminate_all", False):
+                    break
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                LOG.error(f"Failed to terminate {proc}")
 
         if terminated:
             LOG.debug(f"Terminated PIDs: {terminated}")
@@ -278,6 +320,56 @@ class ApplicationLauncherSkill(FallbackSkill):
                     continue
 
                 yield app_info
+
+    @staticmethod
+    def close_window(window_id):
+        try:
+            # Get the list of windows with wmctrl
+            result = subprocess.run(['wmctrl', '-ic', window_id])
+            # windows are returned sorted by order of creation, but we dont have that timestamp
+            # TODO - is this true or just coincidence in my tests? i don't think it is ensured
+            if result.returncode != 0:
+                print("Error: wmctrl command failed.")
+            return True
+        except:
+            return False
+
+    @staticmethod
+    def get_window_process_mapping():
+        """Get a mapping of window objects to process objects on Linux."""
+        windows = []
+
+        try:
+            # Get the list of windows with wmctrl
+            result = subprocess.run(['wmctrl', '-lp'], capture_output=True, text=True)
+            # windows are returned sorted by order of creation, but we dont have that timestamp
+            # TODO - is this true or just coincidence in my tests? i don't think it is ensured
+            if result.returncode != 0:
+                LOG.error("wmctrl command failed.")
+                return windows
+
+            # Process each line in the wmctrl output
+            for line in result.stdout.splitlines():
+                # wmctrl output format: 0x04400007  0  12345  <hostname>  <window_title>
+                fields = line.split()
+                window_id = fields[0]  # Window ID
+                pid = fields[2]  # Process ID (PID)
+
+                window_title = " ".join(fields[4:])  # Window title (everything after hostname)
+                try:
+                    # Get process object using the PID
+                    process = psutil.Process(int(pid))
+                    # Map window ID to the process object
+                    windows.append([window_id, process, process.create_time(), window_title])
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    LOG.error(f"Unable to retrieve process for PID: {pid}")
+
+        except Exception as e:
+            LOG.error(f"Error retrieving window-process mapping: {e}")
+
+        return windows[::-1]
+
+
 
 
 if __name__ == "__main__":

--- a/__init__.py
+++ b/__init__.py
@@ -133,7 +133,8 @@ class ApplicationLauncherSkill(FallbackSkill):
         candidates = []
         best = 0
         for win in windows:
-            score = fuzzy_match(win[1].name(), app)
+            score = max(fuzzy_match(win[1].name(), app),
+                        fuzzy_match(win[-1], app))  # pick best match, process name or window name
             if score < self.settings.get("thresh", 0.85):
                 continue
             if score > best:


### PR DESCRIPTION
relates to https://github.com/OpenVoiceOS/ovos-skill-application-launcher/issues/17

doesnt ask confirmation, but will prefer the most recently opened window in X systems (not wayland)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced application management capabilities, allowing users to close applications by window or process.
	- Introduced new methods for improved window and process management, including fuzzy matching for application names.
	- Added functionality to retrieve window IDs and their corresponding processes for better application control.

- **Bug Fixes**
	- Improved error handling when the `wmctrl` executable is not found, ensuring smoother operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->