### PR TITLE
fix:wayland compat

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -155,7 +155,7 @@ class ApplicationLauncherSkill(FallbackSkill):
 
     def is_running(self, app: str) -> bool:
         """ check if a application is running"""
-        if self.match_window(app):
+        if self.wmctl is not None and self.match_window(app):
             return True
         for p in self.match_process(app):
             return True

--- a/__init__.py
+++ b/__init__.py
@@ -155,7 +155,7 @@ class ApplicationLauncherSkill(FallbackSkill):
 
     def is_running(self, app: str) -> bool:
         """ check if a application is running"""
-        if self.wmctl is not None and self.match_window(app):
+        if self.wmctrl is not None and self.match_window(app):
             return True
         for p in self.match_process(app):
             return True


### PR DESCRIPTION
```
Oct 18 17:50:20 x270.home.lan ovos-core[13490]: [0.076] [glfw error 65544]: X11: The DISPLAY environment variable is missing
Oct 18 17:50:20 x270.home.lan ovos-core[13490]: GLFW initialization failed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for checking if the application is running by ensuring the window manager is available before attempting to match windows, reducing potential errors.

- **Refactor**
	- Enhanced code clarity with formatting adjustments and comments, while maintaining the overall functionality of the application launcher skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->