### PR TITLE
Add fr-fr locale

### DIFF
--- a/locale/fr-fr/already_running.dialog
+++ b/locale/fr-fr/already_running.dialog
@@ -1,0 +1,2 @@
+Je vois que {application} est deja ouverte.
+{application} est deja ouverte.

--- a/locale/fr-fr/close.intent
+++ b/locale/fr-fr/close.intent
@@ -1,0 +1,4 @@
+ferme {application}
+ferme l'application {application}
+quitte {application}
+quitte l'application {application}

--- a/locale/fr-fr/confirm_launch.dialog
+++ b/locale/fr-fr/confirm_launch.dialog
@@ -1,0 +1,2 @@
+Voulez-vous ouvrir une nouvelle fenetre de l'application ?
+Voulez-vous relancer l'application ?

--- a/locale/fr-fr/confirm_switch.dialog
+++ b/locale/fr-fr/confirm_switch.dialog
@@ -1,0 +1,2 @@
+Voulez-vous passer a l'application deja ouverte ?
+Voulez-vous revenir a la fenetre deja ouverte ?

--- a/locale/fr-fr/launch.intent
+++ b/locale/fr-fr/launch.intent
@@ -1,0 +1,3 @@
+lance {application}
+ouvre {application}
+demarre {application}

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,7 @@
+{
+  "examples": [
+    "Ouvre ____",
+    "Lance ____",
+    "Ferme ____"
+  ]
+}

--- a/translations/fr-fr/dialogs.json
+++ b/translations/fr-fr/dialogs.json
@@ -1,0 +1,14 @@
+{
+  "/already_running.dialog": [
+    "Je vois que {application} est deja ouverte.",
+    "{application} est deja ouverte."
+  ],
+  "/confirm_launch.dialog": [
+    "Voulez-vous ouvrir une nouvelle fenetre de l'application ?",
+    "Voulez-vous relancer l'application ?"
+  ],
+  "/confirm_switch.dialog": [
+    "Voulez-vous passer a l'application deja ouverte ?",
+    "Voulez-vous revenir a la fenetre deja ouverte ?"
+  ]
+}

--- a/translations/fr-fr/intents.json
+++ b/translations/fr-fr/intents.json
@@ -1,0 +1,13 @@
+{
+  "/close.intent": [
+    "ferme {application}",
+    "ferme l'application {application}",
+    "quitte {application}",
+    "quitte l'application {application}"
+  ],
+  "/launch.intent": [
+    "lance {application}",
+    "ouvre {application}",
+    "demarre {application}"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a complete `fr-fr` locale tree matching `en-us`
- add the matching `translations/fr-fr` snapshot files
- keep the French prompts natural for spoken assistant use