### PR TITLE
chore(ovos-skill-application-launcher): allow ovos-workshop<9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 padacioso>=0.1.1
-ovos-workshop>=8.0.0,<8.1.0
+ovos-workshop>=8.0.0,<9.0.0
 ovos-utils>=0.3.5
 psutil


### PR DESCRIPTION
Update ovos-workshop dependency upper bound to <9.0.0